### PR TITLE
Develop - Improve Order Placing

### DIFF
--- a/app/clients/MongoDBClient.ts
+++ b/app/clients/MongoDBClient.ts
@@ -1,4 +1,4 @@
-import { Evaluation } from "../models/EvaluationModel";
+import { Evaluation, Trade } from "../models/EvaluationModel";
 import { Db, MongoClient } from "mongodb";
 
 const MONGODB_URI: string = process.env.MONGODB_URI;
@@ -37,34 +37,51 @@ export class MongoDBClient {
 
     public storeEvaluation(
         db: Db,
-        collection: string,
-        data: any
+        data: Evaluation
     ): Promise<Evaluation> {
         return db
-            .collection(collection)
+            .collection("evaluations")
             .insertOne(data)
             .then(() => {
                 console.info("***Evaluation Stored Successfully***");
                 return data;
             })
             .catch(e => {
-                console.error(`Error: storeEvaluation - collection(${collection}).insertOne(${data}) encountered an exception`);
+                console.error(`Error: storeEvaluation - collection(evaluations).insertOne(${data}) encountered an exception`);
                 console.error(e);
                 return null;
             });
     }
 
-    /**
+    public storeTrade(
+        db: Db,
+        data: Trade
+    ): Promise<Trade> {
+        return db
+            .collection("trades")
+            .insertOne(data)
+            .then(() => {
+                console.info("***Trade Stored Successfully***");
+                return data;
+            })
+            .catch(e => {
+                console.error(`Error: storeTrade - collection(trades).insertOne(${data}) encountered an exception`);
+                console.error(e);
+                return null;
+            });
+    }
+
+    /*
      * retrieves the previous evaluation from the database.
      *
      * @param {Db} db
      * @returns {Promise<Array<any>>}
      * @memberof DBRepository
      */
-    public getLastEvaluation(db: Db, collection: string): Promise<Evaluation> {
+    public getLastEvaluation(db: Db): Promise<Evaluation> {
         // This function was changed to this promise format, because returning the pdirect promise was returning undefined.
         return new Promise(function (resolve, reject) {
-            db.collection(collection).find().sort({ $natural: -1 }).toArray(function (err, docs) {
+            db.collection("evaluations").find().sort({ $natural: -1 }).toArray(function (err, docs) {
                 if (err) {
                     console.error(err);
                     return reject(err);

--- a/app/models/EvaluationModel.ts
+++ b/app/models/EvaluationModel.ts
@@ -1,14 +1,15 @@
-import { OrderParams, Account } from "coinbase-pro";
+import { OrderParams, Account, OrderResult } from "coinbase-pro";
 
 export class Evaluation {
 
     public date: Date;
+    public currency: string;
     public portfolioState: PortfolioState;
     public price: number;
     public technicalAnalysis: TechnicalAnalysis;
     public hindsight: Hindsight;
     public placeOrder: boolean;
-    public orders: Array<OrderParams>;
+    public trade: Trade | null;
 
     constructor() {
         this.date = new Date();
@@ -91,4 +92,20 @@ export class PortfolioState {
         this.accounts = acnts;
     }
 
+}
+
+export class Trade {
+    public orderParams: Array<OrderParams>;
+    public orderReciepts: Array<OrderResult>;
+    public result: number = 0; // 0 for no result, 1 for win , 2 for loss
+
+    public getOrderIds() {
+        const ids: Array<string> = [];
+        if (this.orderReciepts) {
+            for (const order of this.orderReciepts) {
+                ids.push(order.id);
+            }
+        }
+        return ids;
+    }
 }

--- a/app/services/DatabaseService.ts
+++ b/app/services/DatabaseService.ts
@@ -1,6 +1,6 @@
 import { MongoDBClient } from '../clients/MongoDBClient';
 import { Db } from 'mongodb';
-import { Evaluation } from '../models/EvaluationModel';
+import { Evaluation, Trade } from '../models/EvaluationModel';
 
 export class DBService {
 
@@ -10,10 +10,10 @@ export class DBService {
         this.dbClient = new MongoDBClient();
     }
 
-    public storeEvaluation(collection: string, evaluation: Evaluation): Promise<Evaluation> {
+    public storeEvaluation(evaluation: Evaluation): Promise<Evaluation> {
         console.info(`Storing Evaluation`);
         return this.dbClient.connectToDatabase().then((db: Db) => {
-            return this.dbClient.storeEvaluation(db, collection, evaluation).then(storedEval => { return storedEval });
+            return this.dbClient.storeEvaluation(db, evaluation).then(storedEval => { return storedEval });
         })
 
     }
@@ -21,7 +21,14 @@ export class DBService {
     public getMostRecentEvaluation(collection: string): Promise<Evaluation> {
         console.info(`Retrieving Most Recent Evaluation`);
         return this.dbClient.connectToDatabase().then((db: Db) => {
-            return this.dbClient.getLastEvaluation(db, collection);
+            return this.dbClient.getLastEvaluation(db);
+        })
+    }
+
+    public storeTrade(trade: Trade) {
+        console.info(`Storing Evaluation`);
+        return this.dbClient.connectToDatabase().then((db: Db) => {
+            return this.dbClient.storeTrade(db, trade).then(storedTrade => { return storedTrade });
         })
     }
 

--- a/app/services/NotificationService.ts
+++ b/app/services/NotificationService.ts
@@ -1,5 +1,5 @@
 import { SNSClient } from "../clients/SNSClient";
-import { OrderParams } from "coinbase-pro";
+import { Trade } from "models/EvaluationModel";
 
 export class NotificationService {
 
@@ -13,13 +13,13 @@ export class NotificationService {
         return this.snsClient.publishMessage(message).then(res => { return true }).catch(err => { console.error(err, err.stack); return false });
     }
 
-    public sendOrderNotification(price: number, orders: Array<OrderParams>) {
+    public sendOrderNotification(price: number, trade: Trade) {
         console.info("Sending Order Info")
         if (!this.snsClient) {
             this.snsClient = new SNSClient();
         }
-        let message = `Placing the following order${orders.length > 1 ? 's' : ''}:\n`;
-        for (let order of orders) {
+        let message = `Placing the following order${trade.orderParams.length > 1 ? 's' : ''}:\n`;
+        for (let order of trade.orderParams) {
             message += `A ${order.type} ${order.side} order for ${order.size} of ${order.product_id} at ${price} totalling ${parseInt(order.size) * price}\n`;
         }
         return this.snsClient.publishMessage(message).then(res => { return true }).catch(err => { console.error(err, err.stack); return false });

--- a/app/workers/Auditor.ts
+++ b/app/workers/Auditor.ts
@@ -1,0 +1,30 @@
+import { Evaluation, Trade } from "../models/EvaluationModel";
+import { DBService } from "../services/DatabaseService";
+
+export class Auditor {
+
+    private dbService: DBService;
+
+    constructor(databaseService: DBService) {
+        this.dbService = databaseService;
+    }
+
+    public async runAudit(evaluation: Evaluation): Promise<Evaluation> {
+        if (evaluation.trade) {
+            await this.storeTradeRecord(evaluation.trade);
+        }
+        return this.storeEvaluation(evaluation);
+    }
+
+    private storeEvaluation(evaluation: Evaluation): Promise<Evaluation> {
+        return this.dbService.storeEvaluation(evaluation);
+    }
+
+    private storeTradeRecord(trade: Trade) {
+        return this.dbService.storeTrade(trade);
+    }
+
+    private reflectOnPastTrades() {
+
+    }
+}

--- a/app/workers/Evaluator.ts
+++ b/app/workers/Evaluator.ts
@@ -1,33 +1,26 @@
 import { AssetService } from "../services/AssetService";
-import { DBService } from "../services/DatabaseService";
 import { ContextModel } from "../models/ContextModel";
-import { Evaluation, TechnicalAnalysis, MACD, PortfolioState } from "../models/EvaluationModel";
-import { Account, LimitOrder, MarketOrder, OrderParams, ProductTicker } from "coinbase-pro";
+import { Evaluation, TechnicalAnalysis, MACD, PortfolioState, Trade } from "../models/EvaluationModel";
+import { Account, LimitOrder, MarketOrder, ProductTicker } from "coinbase-pro";
 import * as CONSTANTS from "../constants/constants";
 import * as TAUtils from "../utilities/TAUtils";
 
 export class Evaluator {
 
     private assetService: AssetService;
-    private dbService: DBService;
 
-    constructor(assetService: AssetService, dbService: DBService) {
+    constructor(assetService: AssetService) {
         this.assetService = assetService;
-        this.dbService = dbService;
     }
 
-    public evaluateAssetAndStoreEvaluation(currency: string, context: ContextModel): Promise<Evaluation> {
-        const evaluation = this.generateFullEvaluation(currency, context);
-        return this.storeEvaluation(currency, evaluation);
-    }
-
-    private generateFullEvaluation(currency: string, context: ContextModel): Evaluation {
+    public generateFullEvaluation(currency: string, context: ContextModel): Evaluation {
         console.info("Generating Evaluation");
         const evaluation = new Evaluation();
+        evaluation.currency = currency;
         evaluation.price = parseFloat(context.ticker.price);
         evaluation.technicalAnalysis = this.runTechnicalAnalysis(context);
         evaluation.portfolioState = this.evalutatePortfolioState(currency, context);
-        evaluation.orders = this.determineActions(currency, context, evaluation.technicalAnalysis, evaluation.portfolioState);
+        evaluation.trade = this.determineActions(currency, context, evaluation.technicalAnalysis, evaluation.portfolioState);
         return evaluation;
     }
 
@@ -75,9 +68,7 @@ export class Evaluator {
         return new PortfolioState(portfolioValue, context.accounts);
     }
 
-    private storeEvaluation(currency: string, evaluation: Evaluation): Promise<Evaluation> {
-        return this.dbService.storeEvaluation(currency, evaluation);
-    }
+
 
     /**
      * Calculates the size of an order to place.
@@ -173,12 +164,63 @@ export class Evaluator {
      * @returns {Array<OrderParams>} Array of orders. empty array if no order to be placed.
      * @memberof Evaluator
      */
-    private determineActions(currency: string, context: ContextModel, technicalAnalysis: TechnicalAnalysis, portfolioState: PortfolioState,): Array<OrderParams> {
-        const orders: Array<OrderParams> = [];
+    private determineActions(currency: string, context: ContextModel, technicalAnalysis: TechnicalAnalysis, portfolioState: PortfolioState,): Trade | null {
+        let trade: Trade = null;
         const macdActionSignal = this.evaluateMACD(technicalAnalysis);
         if (macdActionSignal == CONSTANTS.BUY) {
-            this.craftTrade(currency, context, portfolioState, technicalAnalysis).forEach((order: OrderParams) => { orders.push(order) })
+            // buy action
+            trade = this.craftTrade(currency, context, portfolioState, technicalAnalysis, true);
         } else if (macdActionSignal == CONSTANTS.SELL) {
+            // sell action
+            trade = this.craftTrade(currency, context, portfolioState, technicalAnalysis, false);
+        } else {
+            // no action
+        }
+        return trade;
+    }
+
+    private craftTrade(currency: string, context: ContextModel, portfolioState: PortfolioState, technicalAnalysis: TechnicalAnalysis, buy: boolean): Trade {
+        const trade = new Trade();
+        trade.orderParams = [];
+        if (buy) {
+            const orderSize = this.calculateOrderSize(CONSTANTS.USD, context, portfolioState);
+            const orderSizeNumber = parseFloat(orderSize);
+            if (
+                orderSizeNumber > CONSTANTS.BTC_MINIMUM &&
+                orderSizeNumber < CONSTANTS.BTC_MAXIMUM
+            ) {
+                const limitOrderSize = (
+                    orderSizeNumber / parseFloat(context.ticker.price)
+                ).toFixed(CONSTANTS.BTC_PRECISION);
+                const marketOrder = {
+                    type: CONSTANTS.MARKET_ORDER,
+                    side: CONSTANTS.BUY,
+                    funds: orderSize,
+                    product_id: currency
+                } as MarketOrder;
+                const stopLossOrder = {
+                    type: CONSTANTS.LIMIT_ORDER,
+                    side: CONSTANTS.SELL,
+                    price: this.calculateStopLossLimitOrderPricePoint(context.ticker, technicalAnalysis),
+                    stop_price: this.calculateStopLossLimitOrderPricePoint(context.ticker, technicalAnalysis),
+                    size: limitOrderSize,
+                    product_id: currency,
+                    stop: "loss"
+                } as LimitOrder;
+                const priceTargetOrder = {
+                    type: CONSTANTS.LIMIT_ORDER,
+                    side: CONSTANTS.SELL,
+                    price: this.calculatePriceTarget(context.ticker, technicalAnalysis),
+                    stop_price: this.calculatePriceTarget(context.ticker, technicalAnalysis),
+                    size: limitOrderSize,
+                    product_id: currency,
+                    stop: "entry"
+                } as LimitOrder;
+                trade.orderParams.push(marketOrder);
+                trade.orderParams.push(stopLossOrder);
+                trade.orderParams.push(priceTargetOrder);
+            }
+        } else {
             const orderSize = this.calculateOrderSize(currency.split('-')[0], context, portfolioState);
             const orderSizeNumber = parseFloat(orderSize);
             const sellOrder = {
@@ -191,53 +233,12 @@ export class Evaluator {
                 parseFloat(orderSize) > CONSTANTS.BTC_MINIMUM &&
                 orderSizeNumber < CONSTANTS.BTC_MAXIMUM
             ) {
-                orders.push(sellOrder);
+                trade.orderParams.push(sellOrder);
             }
         }
 
-        return orders;
-    }
 
-    private craftTrade(currency: string, context: ContextModel, portfolioState: PortfolioState, technicalAnalysis: TechnicalAnalysis): Array<OrderParams> {
-        const tradeOrders: Array<OrderParams> = [];
-        const orderSize = this.calculateOrderSize(CONSTANTS.USD, context, portfolioState);
-        const orderSizeNumber = parseFloat(orderSize);
-        if (
-            orderSizeNumber > CONSTANTS.BTC_MINIMUM &&
-            orderSizeNumber < CONSTANTS.BTC_MAXIMUM
-        ) {
-            const limitOrderSize = (
-                orderSizeNumber / parseFloat(context.ticker.price)
-            ).toFixed(CONSTANTS.BTC_PRECISION);
-            const marketOrder = {
-                type: CONSTANTS.MARKET_ORDER,
-                side: CONSTANTS.BUY,
-                funds: orderSize,
-                product_id: currency
-            } as MarketOrder;
-            const stopLossOrder = {
-                type: CONSTANTS.LIMIT_ORDER,
-                side: CONSTANTS.SELL,
-                price: this.calculateStopLossLimitOrderPricePoint(context.ticker, technicalAnalysis),
-                stop_price: this.calculateStopLossLimitOrderPricePoint(context.ticker, technicalAnalysis),
-                size: limitOrderSize,
-                product_id: currency,
-                stop: "loss"
-            } as LimitOrder;
-            const priceTargetOrder = {
-                type: CONSTANTS.LIMIT_ORDER,
-                side: CONSTANTS.SELL,
-                price: this.calculatePriceTarget(context.ticker, technicalAnalysis),
-                stop_price: this.calculatePriceTarget(context.ticker, technicalAnalysis),
-                size: limitOrderSize,
-                product_id: currency,
-                stop: "entry"
-            } as LimitOrder;
-            tradeOrders.push(marketOrder);
-            tradeOrders.push(stopLossOrder);
-            tradeOrders.push(priceTargetOrder);
-        }
-        return tradeOrders;
+        return trade;
     }
 
     private evaluateMACD(technicalAnalysis: TechnicalAnalysis) {

--- a/app/workers/Executor.ts
+++ b/app/workers/Executor.ts
@@ -15,13 +15,14 @@ export class Executor {
         this.notificationService = notificationServ;
     }
 
-    public async executeOrderFromEvaluation(evaluation: Evaluation) {
-        if (evaluation.orders.length > 0) {
-            console.info("Order Request Confirmed");
-            console.log(`${evaluation.orders.length} orders to place`);
-            return this.assetService.executeMultipleOrders(evaluation.orders).then(async (result) => {
-                await this.notificationService.sendOrderNotification(evaluation.price, evaluation.orders);
-                return result;
+    public async executeOrderFromEvaluation(evaluation: Evaluation): Promise<Evaluation> {
+        if (evaluation.trade) {
+            console.info("Trade Request Confirmed");
+            console.log(`${evaluation.trade.orderParams} orders to place`);
+            return this.assetService.executeMultipleOrders(evaluation.trade.orderParams).then(async (result) => {
+                evaluation.trade.orderReciepts = result;
+                await this.notificationService.sendOrderNotification(evaluation.price, evaluation.trade);
+                return evaluation;
             }).catch(err => {
                 return err;
             });


### PR DESCRIPTION
This pull request contains the changes to the bot's buy order process. 

All orders will be now viewed as part of a "trade" action. Each buy trade action will now contain an order to buy, a price target to sell (calculated by the average recent gain%), and a stop loss point to sell preventing major loss. 

- Placing these series of orders allows for me to quantify and evaluate the performance of the bot, based on both profit, and on "win rate". The bot's trades can be considered a "win" or winning trade if the price target is reached. A trade would be considered a loss if the stop loss is hit instead.

A new auditor class was made, which will handle storing trade records and evaluations, maintaining open and existing trade records, and analyzing the data collected. Currently the auditor only handles storing information in the db.